### PR TITLE
feat(bigdata): expose the BigData API

### DIFF
--- a/ittests/tests_bigdata.py
+++ b/ittests/tests_bigdata.py
@@ -1,0 +1,20 @@
+import unittest
+import uuid
+
+from smartobjects.model import OwnerAttribute
+from ittests.it_test import TestHelper
+
+class TestModelService(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.client = TestHelper.getClient()
+
+    def test_big_data_api(self):
+        query = {"from": "event", "select": [{"value": "ts_text_attribute"}], "where": {"ts_text_attribute": {"has": "value"}}}
+        start_export = self.client.bigdata.start_export(query)
+        self.assertTrue(len(start_export.stream_first_pages) > 0)
+
+        for page in start_export.stream_first_pages:
+            streamed = self.client.bigdata.stream_page(page)
+            self.assertTrue(len(streamed.rows) > 10)
+

--- a/smartobjects/bigdata/__init__.py
+++ b/smartobjects/bigdata/__init__.py
@@ -1,0 +1,53 @@
+class StreamPage(object):
+    def __init__(self, *args, **kwargs):
+        if len(args) == 1 and isinstance(args[0], dict):
+            self._source = args[0]
+        elif not args and kwargs:
+            self._source = kwargs
+        else:
+            raise ValueError("Unable to construct StartExport")
+
+        self._next_page = self._source.get('nextPage', None)
+        self._rows = self._source.get('rows', [])
+
+    @property
+    def next_page(self):
+        """The next page you can stream, or None."""
+        return self._next_page
+
+    @property
+    def rows(self):
+        """
+        An array of all the rows of the current page. A row has the column defined
+        in the columns Array returned on the BigDataService.start_export(query)
+        """
+        return self._rows
+
+class StartExport(object):
+    def __init__(self, *args, **kwargs):
+        if len(args) == 1 and isinstance(args[0], dict):
+            self._source = args[0]
+        elif not args and kwargs:
+            self._source = kwargs
+        else:
+            raise ValueError("Unable to construct StartExport")
+
+        self._stream_first_pages = self._source.get('streamsFirstPages', [])
+        self._columns = self._source.get('columns', [])
+
+    @property
+    def stream_first_pages(self):
+        """
+        An array of all the pages that can be streamed. A page can
+        be used in a call to the `BigDataService.stream_page(page)`
+        method.
+        """
+        return self._stream_first_pages
+
+    @property
+    def columns(self):
+        """
+        An array of all the columns you will find in a response from
+        a stream page call.
+        """
+        return self._columns

--- a/smartobjects/bigdata/bigdata.py
+++ b/smartobjects/bigdata/bigdata.py
@@ -1,0 +1,15 @@
+from smartobjects.bigdata import StartExport, StreamPage
+
+class BigDataService(object):
+    def __init__(self, api_manager):
+        """ Initializes BigData with the api manager
+        """
+
+        self.api_manager = api_manager
+
+    def start_export(self, query):
+        return StartExport(self.api_manager.post("bigdata/startexport", query).json())
+
+
+    def stream_page(self, page_id):
+        return StreamPage(self.api_manager.get("bigdata/streampage/{}".format(page_id)).json())

--- a/smartobjects/smartobjects_client.py
+++ b/smartobjects/smartobjects_client.py
@@ -4,6 +4,7 @@ from smartobjects.ingestion.owners import OwnersService
 from smartobjects.ingestion.objects import ObjectsService
 from smartobjects.restitution.search import SearchService
 from smartobjects.model.model import ModelService
+from smartobjects.bigdata.bigdata import BigDataService
 from smartobjects.api_manager import APIManager
 
 
@@ -59,6 +60,7 @@ class SmartObjectsClient(object):
         self.objects = ObjectsService(self._api_manager)
         self.search = SearchService(self._api_manager)
         self.model = ModelService(self._api_manager)
+        self.bigdata = BigDataService(self._api_manager)
 
     @classmethod
     def withToken(cls, token, environment, compression_enabled=True, backoff_config=None):

--- a/tests/mocks/mock_mnubo_backend.py
+++ b/tests/mocks/mock_mnubo_backend.py
@@ -526,3 +526,20 @@ class MockMnuboBackend(object):
             return 500, {"error": "failed to load JSON"}
 
         return 200, self._gzip_encode(json.dumps(obj))
+
+    @route('POST', '^/bigdata/startexport$')
+    def mock_start_export(self, body, params):
+        return 200, {
+            "streamsFirstPages": ["page_id_1"],
+            "columns": [{'label': 'ts_text_attribute', 'type': 'text'}]
+        }
+
+    @route('GET', '^/bigdata/streampage/(.+)$')
+    def mock_stream_page(self, params):
+        return 200, {
+            "nextPage": None,
+            "rows": [
+                ["one"],
+                ["two"]
+            ]
+        }

--- a/tests/tests_bigdata.py
+++ b/tests/tests_bigdata.py
@@ -1,0 +1,33 @@
+import unittest
+
+from smartobjects.api_manager import APIManager
+from smartobjects.bigdata import StartExport, StreamPage
+from smartobjects.bigdata.bigdata import BigDataService
+
+from tests.mocks.local_api_server import LocalApiServer
+
+from builtins import filter
+
+class TestBigDataService(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.server = LocalApiServer()
+        cls.server.start()
+
+        cls.api = APIManager("CLIENT_ID", "CLIENT_SECRET", cls.server.path, compression_enabled=False, backoff_config = None, token_override=None)
+        cls.bigdata = BigDataService(cls.api)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.server.stop()
+
+    def test_big_data_api(self):
+        query = {"from": "event", "select": [{"value": "ts_text_attribute"}], "where": {"ts_text_attribute": {"has": "value"}}}
+        export = self.bigdata.start_export(query)
+        self.assertTrue(len(export.stream_first_pages) == 1)
+
+        for page in export.stream_first_pages:
+            streamed = self.bigdata.stream_page(page)
+            self.assertTrue(len(streamed.rows) == 2)
+            self.assertTrue(streamed.rows[0][0] == "one")
+            self.assertTrue(streamed.rows[1][0] == "two")


### PR DESCRIPTION
Expose the Big Data API in the client.

As I said to @blemoine, I leave it to user to see how they want to fetch the different pages in parallel.

As shown in the tests and IT tests, this can be used like:

```python
import time
import sys

from smartobjects import SmartObjectsClient
from smartobjects import Environments

def main():
    key = "id"
    secret = "secret"
    client = SmartObjectsClient(key, secret, Environments.Sandbox)

    query = {"from": "event", "select": [{"value": "ts_text_attribute"}], "where": {"ts_text_attribute": {"has": "value"}}}
    start_export = client.bigdata.start_export(query)
    print(start_export.stream_first_pages)
    print(start_export.columns)

    for page in start_export.stream_first_pages:
        print("fetching page {}".format(page))
        stream_page = client.bigdata.stream_page(page)
        rows = stream_page.rows
        for row in rows:
            print(row[0])

if __name__ == "__main__":
    main()
```