### PR TITLE
fix(types): object and event types keys

### DIFF
--- a/ittests/tests_model.py
+++ b/ittests/tests_model.py
@@ -51,11 +51,14 @@ class TestModelService(unittest.TestCase):
             ets = self.client.model.get_event_types()
 
             self.assertTrue(len(ets) > 2)
+            not_empty = [et for et in ets if et.key == 'event_type1']
+            self.assertTrue(len(not_empty[0].timeseries_keys) > 0)
 
         def test_object_types(self):
             ots = self.client.model.get_object_types()
-
             self.assertTrue(len(ots) > 1)
+            not_empty = [ot for ot in ots if ot.key == 'object_type1']
+            self.assertTrue(len(not_empty[0].object_attribute_keys) > 0)
 
         def test_sandbox_ops(self):
             # we can't reset in it test, all sdk integration tests' use the same namespace

--- a/smartobjects/model/__init__.py
+++ b/smartobjects/model/__init__.py
@@ -13,6 +13,13 @@ class ObjectType(object):
         for rawoa in raw_object_attributes:
             self._object_attribute_keys.append(rawoa.get("key"))
 
+    @classmethod
+    def withKeys(cls, source):
+        if not isinstance(source, dict):
+            raise ValueError("Invalid arguments")
+        source['objectAttributes'] = [ { 'key': objKey } for objKey in source.get('objectAttributesKeys', [])]
+        return ObjectType(source)
+
     @property
     def key(self):
         """ key of the object type - the key is a unique identifier """
@@ -50,7 +57,14 @@ class EventType(object):
         raw_timeseries_keys = self._source.get('timeseries', [])
         self._timeseries_keys = []
         for rawts in raw_timeseries_keys:
-                self._timeseries_keys.append(rawts.get("key"))
+            self._timeseries_keys.append(rawts.get("key"))
+
+    @classmethod
+    def withKeys(cls, source):
+        if not isinstance(source, dict):
+            raise ValueError("Invalid arguments")
+        source['timeseries'] = [ { 'key': etKey } for etKey in source.get('timeseriesKeys', [])]
+        return EventType(source)
 
     @property
     def key(self):

--- a/smartobjects/model/model.py
+++ b/smartobjects/model/model.py
@@ -304,7 +304,7 @@ class ModelService(object):
         :returns: [ObjectType]
         """
         _json = self.api_manager.get('model/objectTypes').json()
-        return [ObjectType(evt) for evt in _json]
+        return [ObjectType.withKeys(evt) for evt in _json]
 
     def get_event_types(self):
         """ All event types in the target environment.
@@ -312,4 +312,4 @@ class ModelService(object):
         :returns: [EventType]
         """
         _json = self.api_manager.get('model/eventTypes').json()
-        return [EventType(evt) for evt in _json]
+        return [EventType.withKeys(evt) for evt in _json]


### PR DESCRIPTION
the payload from export contains eventTypes[].timeseries and
objectTypes[].objectAttributes while model/eventTypes has
[].timeseriesKeys and model/objectTypes has [].objectAttributesKeys and