### PR TITLE
fix(api): objects/owners create better error message

### DIFF
--- a/smartobjects/ingestion/objects.py
+++ b/smartobjects/ingestion/objects.py
@@ -12,6 +12,9 @@ class ObjectsService(object):
         if not object:
             raise ValueError('Object body cannot be null.')
 
+        if not isinstance(object, dict):
+            raise ValueError('Expecting a dictionary.')
+
         if 'x_device_id' not in object or not object['x_device_id']:
             raise ValueError('x_device_id cannot be null or empty.')
 

--- a/smartobjects/ingestion/owners.py
+++ b/smartobjects/ingestion/owners.py
@@ -13,6 +13,8 @@ class OwnersService(object):
     def _validate_owner(self, owner):
         if not owner:
             raise ValueError("Owner body cannot be null")
+        if not isinstance(owner, dict):
+            raise ValueError('Expecting a dictionary.')
         if 'username' not in owner or not owner['username']:
             raise ValueError("username cannot be null or empty.")
 

--- a/tests/tests_objects.py
+++ b/tests/tests_objects.py
@@ -35,6 +35,11 @@ class TestObjectsService(unittest.TestCase):
         })
         self.assertIn('vin1234', self.server.server.backend.objects)
 
+    def test_create_array(self):
+        with self.assertRaises(ValueError) as ctx:
+            self.objects.create([{"x_device_id": "vin12345", "x_object_type": "car"}])
+            self.assertEqual(ctx.exception.message, "Expecting a dictionary.")
+
     def test_create_duplicate(self):
         self.objects.create({"x_device_id": "duplicated_id", "x_object_type": "cow"})
         self.assertIn('duplicated_id', self.server.server.backend.objects)

--- a/tests/tests_owners.py
+++ b/tests/tests_owners.py
@@ -33,6 +33,11 @@ class TestOwnersService(unittest.TestCase):
         })
         self.assertIn('owner_1', self.server.server.backend.owners)
 
+    def test_create_array(self):
+        with self.assertRaises(ValueError) as ctx:
+            self.owners.create([{'username': 'owner_1'}])
+            self.assertEqual(ctx.exception.message, "Expecting a dictionary.")
+
     def test_create_username_missing(self):
         with self.assertRaises(ValueError) as ctx:
             self.owners.create({'location': 'bedroom'})


### PR DESCRIPTION
if you call objects.create or owners.create with an array you get an
irrelevant error message.