### PR TITLE
fix(token): check the response before assuming json

### DIFF
--- a/smartobjects/api_manager.py
+++ b/smartobjects/api_manager.py
@@ -135,8 +135,8 @@ class APIManager(object):
         requested_at = datetime.datetime.now()
 
         r = self.__session.post(self.get_auth_url(), headers=self.get_token_authorization_header())
-        json_response = r.json()
         r.raise_for_status()
+        json_response = r.json()
 
         return {
             'access_token': json_response['access_token'],

--- a/tests/mocks/mock_mnubo_backend.py
+++ b/tests/mocks/mock_mnubo_backend.py
@@ -42,6 +42,10 @@ class MockMnuboBackend(object):
             "jti": str(uuid.uuid4())
         }
 
+    @route('POST', '^/fail/oauth/.*')
+    def auth(self, body, params):
+        return 502, '<h1ml>hey oh</html>'
+
     @route('GET', '^/unvailable/(.+)$')
     def unavailable(self, params):
         count = int(params[0])

--- a/tests/tests_api_manager.py
+++ b/tests/tests_api_manager.py
@@ -1,5 +1,5 @@
 import unittest
-from requests import Response
+from requests import Response, HTTPError
 import datetime
 
 from smartobjects import APIManager
@@ -40,6 +40,12 @@ class TestsApiManager(unittest.TestCase):
         self.assertIn("access_token", api.access_token)
         self.assertIn("expires_in", api.access_token)
         self.assertIn("requested_at", api.access_token)
+
+
+    def test_fetch_token_at_init_fail(self):
+        with self.assertRaises(HTTPError) as ctx:
+            api = APIManager("CLIENT_ID", "CLIENT_SECRET", self.server.path + '/fail', compression_enabled=False, backoff_config = None, token_override=None)
+            self.assertTrue(ctx.exception.message.startswith("502 Server Error: Bad Gateway for url: http:"))
 
     def test_get_api_url(self):
         url = self.api.get_api_url()


### PR DESCRIPTION
we avoid attempting to read json in the cases where an error has happenned
and the payload is not json