### PR TITLE
ci(pypi): skip deploy when the version exists

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,5 +31,6 @@ jobs:
         provider: pypi
         username: __token__
         password: $PYPI_API_KEY
+        skip_existing: true
         on:
           branch: master


### PR DESCRIPTION
adding the `skip_existing: true` flag